### PR TITLE
Update crispy-forms to 1.7.2 for bugfixes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 [packages]
 django = "==2.2.0"
 django-allauth = "==0.39.0"
-django-crispy-forms = "==1.7.1"
+django-crispy-forms = "==1.7.2"
 django-debug-toolbar = "==1.11"
 
 [requires]


### PR DESCRIPTION
django-crispy-forms had some bug fixes between 1.7.1 to 1.7.2 which include fixing issues related to improperly rendering form errors due to an unecessary bootstrap tag as seen here django-crispy-forms/django-crispy-forms#779