### PR TITLE
Fix for TemplateSyntaxError occurring on path "/accounts/password/set/" 

### DIFF
--- a/templates/account/password_set.html
+++ b/templates/account/password_set.html
@@ -7,9 +7,10 @@
 {% block content %}
 <form method="POST" action="" class="password_set">
   {% csrf_token %}
-  {% password_set_form | crispy %}
+  {{ password_set_form | crispy }}
   <div class="form-actions">
-    <button class="btn btn-primary" type="submit" name="action" value="{% trans "Set Password" %}"/>Change Password</button>
+    <button class="btn btn-primary" type="submit" name="action" value="{% trans "Set Password" %}" />Change
+    Password</button>
   </div>
 </form>
 {% endblock content %}


### PR DESCRIPTION
The path `/accounts/password/set/` is throwing a `TemplateSyntaxError`. 

`TemplateSyntaxError at /accounts/password/set/
Invalid block tag on line 28: 'password_set_form', expected 'endblock'. Did you forget to register or load this tag?`

This is caused by `password_set.html` that uses a template tag `{% %}` to load the `password_set_form` instead of using a template variable `{{ }}`

This PR changes it to use variable.
Thank you for making this project.
