### PR TITLE
added requirements.txt for use in python venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,19 @@
+-i https://pypi.org/simple
+asgiref==3.2.7
+certifi==2020.4.5.1
+chardet==3.0.4
+defusedxml==0.6.0
+django-allauth==0.41.0
+django-crispy-forms==1.9.0
+django-debug-toolbar==2.2
+django==3.0.5
+idna==2.9
+oauthlib==3.1.0
+python3-openid==3.1.0
+pytz==2019.3
+requests-oauthlib==1.3.0
+requests==2.23.0
+sqlparse==0.3.1
+urllib3==1.25.8
+whitenoise==5.0.1
+# To generate this file run: pipenv lock -r > requirements.txt


### PR DESCRIPTION
I added `requirements.txt` for when using this template with python `venv` (which is the built in way for creating virtual environments). Some people use pipenv and others use venv. I understand that you are trying to keep this as lean as possible, however, I believe it is good to have the requirements.txt since it doesn't really add confusion and is helpful for those that use `venv`.

Thanks for maintaining this template @wsvincent .