### PR TITLE
docker-compose.yml & Dockerfile cleanup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,3 @@ WORKDIR /code
 # Install dependencies
 COPY Pipfile Pipfile.lock /code/
 RUN pip install pipenv && pipenv install --system
-
-# Copy project
-COPY . /code/

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ pipenv shell
 ### Docker
 
 ```
-$ docker build .
+$ docker-compose build
 $ docker-compose up -d
 $ docker-compose exec web python manage.py migrate
 $ docker-compose exec web python manage.py createsuperuser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,13 @@
-version: '3.8'
+version: '3.7'
 
 services:
   web:
+    # Build Dockerfile found in this dir.
     build: .
-    command: python /code/manage.py runserver 0.0.0.0:8000
-    volumes:
-      - .:/code
     ports:
+      # Ports allows capture of host port requests
       - 8000:8000
+    volumes:
+      # Maps host current dir to container /code dir.  Changes are live!
+      - .:/code
+    command: ./manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
docker-compose already has the host current dir mapped to /code so there
is no need for COPY . /code/ to copy the code into the dockerfile.

WORKDIR /code is set in the dockerfile   so docker-compose can just use
 ./manage.py to run the server.

Changed the README.md to use docker-compose build vs docker build . as
the build parameters are contained in the docker-compose.yml  file.