### PR TITLE
Add DEFAULT_AUTO_FIELD

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -86,6 +86,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField' # Django 3.2 recommendation
+
 # PASSWORDS
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators


### PR DESCRIPTION
Hey William, I love DjangoX and would love to contribute. 
Django 3.2 suggests adding this Default setting if users are creating models without "id", I thought the project could use this suggestion as well.