### PR TITLE
Add basic tests to the pages app views

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ INTERNAL_IPS = [ip[:-1] + "1" for ip in ips]
 (djangox) $ python manage.py runserver
 
 # Load the site at http://127.0.0.1:8000
+
+# For running unit tests, first you will need to run
+(djangox) $ python manage.py collectstatic
+# And then
+(djangox) $ python manage.py test
 ```
 
 ----

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1,3 +1,28 @@
 from django.test import TestCase
+from django.urls import reverse, resolve
 
-# Create your tests here.
+from . import views
+
+
+class HomePageViewTests(TestCase):
+    def test_uses_correct_html(self):
+        response = self.client.get(reverse('home'))
+        self.assertTemplateUsed(response, views.HomePageView.template_name)
+
+    def test_uses_correct_view(self):
+        response = resolve(reverse('home'))
+        self.assertEqual(
+            response.func.__name__, views.HomePageView.as_view().__name__
+        )
+
+
+class AboutPageViewTests(TestCase):
+    def test_uses_correct_html(self):
+        response = self.client.get(reverse('about'))
+        self.assertTemplateUsed(response, views.AboutPageView.template_name)
+
+    def test_uses_correct_view(self):
+        response = resolve(reverse('about'))
+        self.assertEqual(
+            response.func.__name__, views.AboutPageView.as_view().__name__
+        )


### PR DESCRIPTION
I think that it is very cool (and also necessary) to show a little bit about unit testing.

I had to run the `python manage.py collecstatic` command before being able to  actually run the tests. This due to an error related to WhiteNoise. I was getting the following error `ValueError: Missing staticfiles manifest entry for 'images/favicon.ico'` (this is the [Stack Overflow link](https://stackoverflow.com/questions/44160666/valueerror-missing-staticfiles-manifest-entry-for-favicon-ico) I used to solve the problem).