### PR TITLE
fix to psycopg version and docker directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.10-slim-buster
 
 # Set Python environment variable
-FROM python:${PYTHON_VERSION}
+FROM python:3.10-slim-buster
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ version: '3.9'
 services:
   web:
     build: .
-    command: python /code/manage.py runserver 0.0.0.0:8000
+    command: python /app/manage.py runserver 0.0.0.0:8000
     volumes:
-      - .:/code
+      - .:/app
     ports:
       - 8000:8000
     depends_on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ django-allauth==0.51.0
 django-crispy-forms==1.14.0
 django-debug-toolbar==3.2.4
 whitenoise==6.2.0
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.5


### PR DESCRIPTION
The directory in the docker file and docker-compose file were not matching, so when you run start-app, it didn't copy to the local folder. I updated the python env variable and psycopg version caused docker compose up to fail. 