### PR TITLE
Upgrade to requests 2.30.0 and urllib3 2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,9 @@ psycopg-binary==3.1.8
 pycparser==2.21
 PyJWT==2.6.0
 python3-openid==3.2.0
-requests==2.28.2
+requests==2.30.0
 requests-oauthlib==1.3.1
 sqlparse==0.4.3
 typing_extensions==4.5.0
-urllib3==1.26.14
+urllib3==2.0.2
 whitenoise==6.4.0


### PR DESCRIPTION
Hello, urllib3 maintainer here :wave: 

To upgrade to the next release version of urllib3, requests need to be upgraded too, which is something that dependabot does not handle well, see https://github.com/lolrenx/pf-wagtail/pull/140 for an example.