### PR TITLE
typing_extensions to 4.8.0 to work with python3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ python3-openid==3.2.0
 requests==2.28.2
 requests-oauthlib==1.3.1
 sqlparse==0.4.3
-typing_extensions==4.5.0
+typing_extensions==4.8.0
 urllib3==1.26.14
 whitenoise==6.5.0


### PR DESCRIPTION
Watching for file changes with StatReloader
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1052, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 989, in run
    self._target(*self._args, **self._kwargs)
  File "/root/django/lib/python3.12/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/root/django/lib/python3.12/site-packages/django/core/management/commands/runserver.py", line 125, in inner_run
    autoreload.raise_last_exception()
  File "/root/django/lib/python3.12/site-packages/django/utils/autoreload.py", line 87, in raise_last_exception
    raise _exception[1]
  File "/root/django/lib/python3.12/site-packages/django/core/management/__init__.py", line 394, in execute
    autoreload.check_errors(django.setup)()
  File "/root/django/lib/python3.12/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/root/django/lib/python3.12/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/root/django/lib/python3.12/site-packages/django/apps/registry.py", line 124, in populate
    app_config.ready()
  File "/root/django/lib/python3.12/site-packages/debug_toolbar/apps.py", line 23, in ready
    for cls in DebugToolbar.get_panel_classes():
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/django/lib/python3.12/site-packages/debug_toolbar/toolbar.py", line 134, in get_panel_classes
    import_string(panel_path) for panel_path in dt_settings.get_panels()
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/django/lib/python3.12/site-packages/django/utils/module_loading.py", line 30, in import_string
    return cached_import(module_path, class_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/django/lib/python3.12/site-packages/django/utils/module_loading.py", line 15, in cached_import
    module = import_module(module_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1381, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1354, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1325, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 929, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 994, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/root/django/lib/python3.12/site-packages/debug_toolbar/panels/sql/__init__.py", line 1, in <module>
    from debug_toolbar.panels.sql.panel import SQLPanel
  File "/root/django/lib/python3.12/site-packages/debug_toolbar/panels/sql/panel.py", line 14, in <module>
    from debug_toolbar.panels.sql.tracking import wrap_cursor
  File "/root/django/lib/python3.12/site-packages/debug_toolbar/panels/sql/tracking.py", line 13, in <module>
    import psycopg
  File "/root/django/lib/python3.12/site-packages/psycopg/__init__.py", line 9, in <module>
    from . import pq  # noqa: F401 import early to stabilize side effects
    ^^^^^^^^^^^^^^^^
  File "/root/django/lib/python3.12/site-packages/psycopg/pq/__init__.py", line 16, in <module>
    from . import abc
  File "/root/django/lib/python3.12/site-packages/psycopg/pq/abc.py", line 9, in <module>
    from typing_extensions import TypeAlias
  File "/root/django/lib/python3.12/site-packages/typing_extensions.py", line 1174, in <module>
    class TypeVar(typing.TypeVar, _DefaultMixin, _root=True):
TypeError: type 'typing.TypeVar' is not an acceptable base type


Was getting the above error in python3.12. Changed the version of typing_extension to 4.8.0 to get it to work.