### PR TITLE
Remove USE_L10N setting

### DIFF
--- a/django_project/settings.py
+++ b/django_project/settings.py
@@ -116,9 +116,6 @@ TIME_ZONE = "UTC"
 # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-USE_I18N
 USE_I18N = True
 
-# https://docs.djangoproject.com/en/dev/ref/settings/#use-l10n
-USE_L10N = True
-
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-tz
 USE_TZ = True
 


### PR DESCRIPTION
The USE_L10N setting is deprecated.
Starting with Django 5.0, localized formatting of data will always be enabled. For example Django will display numbers and dates using the format of the current locale.