### PR TITLE
Update README.md docker commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ INTERNAL_IPS = [ip[:-1] + "1" for ip in ips]
 And then proceed to build the Docker image, run the container, and execute the standard commands within Docker.
 
 ```
-$ docker-compose up -d --build
-$ docker-compose exec web python manage.py migrate
-$ docker-compose exec web python manage.py createsuperuser
+$ docker compose up -d --build
+$ docker compose exec web python manage.py migrate
+$ docker compose exec web python manage.py createsuperuser
 # Load the site at http://127.0.0.1:8000
 ```
 


### PR DESCRIPTION
Changed 'docker-compose' to 'docker compose' in the install instructions because latest docker version have update from python to go, therefore 'docker-compose' is now outdated and obsolete in future versions of docker. So users using the latest versions of docker will not be able to use 'docker-compose' to but MUST use 'docker compose' instead. 

I had to read up on stackO how to install docker which led me to the official docs to uninstall and reinstall the official docker. Then i couldnt check the version when i used the dashes so i went back to stackO and found out the commands have changed.